### PR TITLE
Calbox Cutoff and Rating Bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiger-junction",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiger-junction",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@supabase/auth-helpers-sveltekit": "^0.10.1",
         "@supabase/supabase-js": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiger-junction",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/components/recal/elements/save/CalBox.svelte
+++ b/src/lib/components/recal/elements/save/CalBox.svelte
@@ -110,9 +110,9 @@ on:mouseleave={() => hovered = false}>
             {courseCode} {section.title}
         </div>
         
-        {#if $searchSettings.style["Always Show Rooms"] || hovered}
+        {#if ($searchSettings.style["Always Show Rooms"] || hovered) && section.room }
             <div class="font-light">
-                {section.room ? section.room : ""}
+                {section.room}
             </div>
         {/if}
 

--- a/src/lib/components/recal/modals/AdvancedSearch.svelte
+++ b/src/lib/components/recal/modals/AdvancedSearch.svelte
@@ -24,6 +24,7 @@ let maxInput: number = $searchSettings.filters["Rating"].max;
 const handleMin = (e: Event) => {
     let target = e.target as HTMLInputElement;
     minInput = parseFloat(target.value);
+    if (Number.isNaN(minInput)) return;
     if (minInput > maxInput) minInput = maxInput;
     if (minInput < 0) minInput = 0;
     if (minInput > 5) minInput = 5;
@@ -37,6 +38,7 @@ const handleMin = (e: Event) => {
 const handleMax = (e: Event) => {
     let target = e.target as HTMLInputElement;
     maxInput = parseFloat(target.value);
+    if (Number.isNaN(maxInput)) return;
     if (maxInput < minInput) maxInput = minInput;
     if (maxInput < 0) maxInput = 0;
     if (maxInput > 5) maxInput = 5;


### PR DESCRIPTION
Fix a bug caused when a section has no course, and so the negative spacing with the empty div would cause the bottom of the text to slightly cut off. Ensure that NaN rating filters cannot be inputted by returning from the state-changing function if the input is NaN, and keeping the state as the previous value until a valid input is detected. 