### PR TITLE
Export improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiger-junction",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiger-junction",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@supabase/auth-helpers-sveltekit": "^0.10.1",
         "@supabase/supabase-js": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiger-junction",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/components/elements/Modal.svelte
+++ b/src/lib/components/elements/Modal.svelte
@@ -45,17 +45,4 @@ dialog[open] {
         transform: scale(1);
     }
 }
-
-dialog[open]::backdrop {
-    animation: fade 0.2s ease-out;
-}
-
-@keyframes fade {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
 </style>

--- a/src/lib/components/elements/Toast.svelte
+++ b/src/lib/components/elements/Toast.svelte
@@ -16,13 +16,25 @@ in:fade={{ duration: 150 }}
 out:fade={{ duration: 300 }}
 on:click={() => dispatch("dismiss")}>
     {#if type === "info"}
-        {infoIcon}
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" 
+    class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+    </svg>      
     {:else if type === "error"}
-        <img class="w-6" src={errorIcon} alt="Info Icon">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" 
+    class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+    </svg>      
     {:else if type === "warning"}
-        W
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" 
+    class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+    </svg>      
     {:else}
-        <img class="w-6" src={infoIcon} alt="Info Icon">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" 
+    class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>      
     {/if}
 
     <div class="ml-4">

--- a/src/lib/components/elements/Toast.svelte
+++ b/src/lib/components/elements/Toast.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 import { createEventDispatcher } from "svelte";
 import { fade } from "svelte/transition";
-import infoIcon from "$lib/img/icons/infoicon.svg"
-import errorIcon from "$lib/img/icons/blockicon.svg";
 
 const dispatch = createEventDispatcher();
 

--- a/src/lib/components/recal/modals/ExportCal.svelte
+++ b/src/lib/components/recal/modals/ExportCal.svelte
@@ -72,6 +72,11 @@ const createIcal = async () => {
         }
     }
 
+    if (events.length === 0) {
+        toastStore.add("warning", "No confirmed courses to export!");
+        return;
+    }
+
     await createEvents(events, async (error, value) => {
         if (error) {
             console.log(error);


### PR DESCRIPTION
Add warning message when attempting to export with 0 confirmed courses. Remove problem when a modal opens on top of a modal (specifically opening the palette modal), causing the backdrop of the modal dialog to flash, which was a bit annoying.