### PR TITLE
Fix search save spacing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiger-junction",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiger-junction",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "@supabase/auth-helpers-sveltekit": "^0.10.1",
         "@supabase/supabase-js": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiger-junction",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/components/recal/Top.svelte
+++ b/src/lib/components/recal/Top.svelte
@@ -29,9 +29,10 @@ const handleTermChange = async (term: number) => {
     await fetchUserSchedules(supabase, term);
     await populatePools(supabase, term);
     
-    if ($schedules[term].length > 0)
+    if ($schedules[term].length > 0 && term === $currentTerm) {
         currentSchedule.set($schedules[term][0].id);
-
+    }
+        
     $ready = true;
 }
 

--- a/src/lib/components/recal/elements/save/Saved.svelte
+++ b/src/lib/components/recal/elements/save/Saved.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { currentSchedule, isResult, ready, recal, retop, searchSettings } from "$lib/stores/recal";
+import { currentSchedule, isResult, ready, recal, searchSettings } from "$lib/stores/recal";
 import type { SupabaseClient } from "@supabase/supabase-js";
 // import ClassicSearch from "../cards/ClassicSearch.svelte";
 import MinimalBase from "../cards/MinimalBase.svelte";
@@ -35,7 +35,7 @@ $: colorChange = $calColors;
 
     {#if saved.length > 0}
     <div class="flex flex-col overflow-hidden rounded-xl 
-    {$isResult ? "max-h-[10vh]" : "max-h-[75vh]"}">
+    {$isResult ? "max-h-[18vh]" : "max-h-[75vh]"}">
         <div class="overflow-y-auto">
             {#key saved && colorChange}
             {#each saved as course}

--- a/src/lib/components/recal/elements/search/SearchResults.svelte
+++ b/src/lib/components/recal/elements/search/SearchResults.svelte
@@ -16,7 +16,7 @@ $: resetKey = [$searchResults, $darkTheme, $research]
     </div> <!-- * End Head -->
 
     <div class="flex flex-col overflow-auto border-2 rounded-xl
-    max-h-[60vh]">
+    max-h-[58vh]">
         <div class="overflow-y-auto">
             {#key resetKey}
             {#each $searchResults as course}


### PR DESCRIPTION
Fix a bug caused by rapidly switching the terms when they are not loaded, and slightly adjust the spacing between search results and saved courses so that when a saved course is expanded, it doesn't appear as if the rest are cut off. 