### PR TITLE
Fix enrollment calculation: count per section type

### DIFF
--- a/apps/engine/src/mcp/tools/courses.ts
+++ b/apps/engine/src/mcp/tools/courses.ts
@@ -10,6 +10,39 @@ import { formatSection, termCodeToName, daysToBitmask, timeToValue } from "../he
 import { buildResolutionError, resolveCourseInput } from "../resolvers.js";
 import type { AuthContext } from "../context.js";
 
+/**
+ * Calculate true enrollment by grouping sections by type.
+ * Each student enrolls in one section per type (one lecture, one precept, etc.).
+ * The true enrollment is the sum within the type with the highest total
+ * (typically Lecture, which all students share).
+ */
+function calculateEnrollment(sections: { title: string; tot: number | null; cap: number | null }[]): {
+  enrolled: number;
+  capacity: number;
+} {
+  // Group by section type prefix (L=Lecture, P=Precept, C=Class, S=Seminar, etc.)
+  const byType = new Map<string, { enrolled: number; capacity: number }>();
+  for (const s of sections) {
+    const typeMatch = s.title.match(/^([A-Z]+)/);
+    const type = typeMatch ? typeMatch[1] : s.title;
+    const entry = byType.get(type) ?? { enrolled: 0, capacity: 0 };
+    entry.enrolled += s.tot ?? 0;
+    entry.capacity += s.cap ?? 0;
+    byType.set(type, entry);
+  }
+
+  if (byType.size === 0) return { enrolled: 0, capacity: 0 };
+
+  // Pick the type with the highest total enrollment — that's the true student count
+  // (Lecture sections contain all students; precepts split them into smaller groups)
+  let best = { enrolled: 0, capacity: 0 };
+  for (const entry of byType.values()) {
+    if (entry.enrolled > best.enrolled) best = entry;
+  }
+
+  return best;
+}
+
 interface JunctionContext {
   supabase: SupabaseClient;
   authContext?: AuthContext;
@@ -461,8 +494,7 @@ export function registerCourseTools(server: McpServer, db: NodePgDatabase, junct
             .where(eq(schema.sections.courseId, course.id))
             .orderBy(asc(schema.sections.id));
 
-          const totalEnrolled = sections.reduce((sum, s) => sum + (s.tot ?? 0), 0);
-          const totalCapacity = sections.reduce((sum, s) => sum + (s.cap ?? 0), 0);
+          const { enrolled: totalEnrolled, capacity: totalCapacity } = calculateEnrollment(sections);
 
           const evals = await db
             .select({ rating: schema.evaluations.rating, evalTerm: schema.evaluations.evalTerm })
@@ -522,8 +554,7 @@ export function registerCourseTools(server: McpServer, db: NodePgDatabase, junct
         .where(eq(schema.sections.courseId, resolved.value.id))
         .orderBy(asc(schema.sections.id));
 
-      const totalEnrolled = sections.reduce((sum, s) => sum + (s.tot ?? 0), 0);
-      const totalCapacity = sections.reduce((sum, s) => sum + (s.cap ?? 0), 0);
+      const { enrolled: totalEnrolled, capacity: totalCapacity } = calculateEnrollment(sections);
 
       return {
         content: [

--- a/apps/engine/src/mcp/tools/snatch.ts
+++ b/apps/engine/src/mcp/tools/snatch.ts
@@ -7,6 +7,25 @@ import * as schema from "../../db/schema.js";
 import { formatSection, termCodeToName } from "../helpers.js";
 import type { AuthContext } from "../context.js";
 
+function calculateEnrollment(sections: { title: string; tot: number | null; cap: number | null }[]): {
+  enrolled: number; capacity: number;
+} {
+  const byType = new Map<string, { enrolled: number; capacity: number }>();
+  for (const s of sections) {
+    const type = s.title.match(/^([A-Z]+)/)?.[1] ?? s.title;
+    const entry = byType.get(type) ?? { enrolled: 0, capacity: 0 };
+    entry.enrolled += s.tot ?? 0;
+    entry.capacity += s.cap ?? 0;
+    byType.set(type, entry);
+  }
+  if (byType.size === 0) return { enrolled: 0, capacity: 0 };
+  let best = { enrolled: 0, capacity: 0 };
+  for (const entry of byType.values()) {
+    if (entry.enrolled > best.enrolled) best = entry;
+  }
+  return best;
+}
+
 function getSnatchConfig(): { url: string; token: string } | null {
   const url = process.env.SNATCH_URL?.trim();
   const token = process.env.SNATCH_TOKEN?.trim();
@@ -385,8 +404,7 @@ export function registerSnatchTools(
           .from(schema.sections)
           .where(eq(schema.sections.courseId, offering.courseId));
 
-        const totalCap = sections.reduce((s, sec) => s + (sec.cap ?? 0), 0);
-        const totalEnrolled = sections.reduce((s, sec) => s + (sec.tot ?? 0), 0);
+        const { enrolled: totalEnrolled, capacity: totalCap } = calculateEnrollment(sections);
         const closedCount = sections.filter((s) => s.status === "closed").length;
         const canceledCount = sections.filter((s) => s.status === "canceled").length;
         const fillRate = totalCap > 0 ? Math.round((totalEnrolled / totalCap) * 100) : 0;


### PR DESCRIPTION
## Summary
- Enrollment stats were summing across ALL sections (lectures + precepts + labs), double/triple counting students
- Now groups sections by type prefix and uses the type with highest enrollment as true student count
- Example: COS 126 with 1 lecture (300 enrolled) + 15 precepts (20 each) now correctly reports 300, not 600

## Files changed
- `apps/engine/src/mcp/tools/courses.ts` — `get_enrollment_stats` + `compare_courses`
- `apps/engine/src/mcp/tools/snatch.ts` — `get_course_historical_demand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)