### PR TITLE
Fix MCP session leak: accept empty-body DELETE

### DIFF
--- a/apps/ask-gateway/app/mcp_client.py
+++ b/apps/ask-gateway/app/mcp_client.py
@@ -110,10 +110,20 @@ class McpHttpClient:
     async def close(self) -> None:
         try:
             if self._session_id:
-                await self._client.delete(
-                    self._mcp_url,
-                    headers=self._headers(include_session=True),
-                )
+                # DELETE carries no body, so omit `content-type: application/json`
+                # to avoid a 400 from strict JSON parsers on the server.
+                headers = self._headers(include_session=True)
+                headers.pop("content-type", None)
+                response = await self._client.delete(self._mcp_url, headers=headers)
+                if response.status_code >= 400:
+                    logger.warning(
+                        "MCP session close failed: status=%s session=%s body=%s",
+                        response.status_code,
+                        self._session_id,
+                        response.text[:200],
+                    )
+        except Exception as exc:  # pragma: no cover - close must never raise
+            logger.warning("MCP session close errored for %s: %s", self._session_id, exc)
         finally:
             await self._client.aclose()
 

--- a/apps/engine/src/routes/mcp.ts
+++ b/apps/engine/src/routes/mcp.ts
@@ -51,6 +51,27 @@ interface McpRouteOptions {
 const mcpRoutes: FastifyPluginAsync<McpRouteOptions> = async (app, opts) => {
   const scope = opts.scope ?? "full";
   const sessions = new Map<string, McpSession>();
+
+  // Accept empty JSON bodies on this plugin's routes. Without this, DELETE /
+  // requests from clients that set `content-type: application/json` but send
+  // no body (httpx does this on DELETE) are rejected with 400 by Fastify's
+  // default parser, so `transport.close()` never runs and sessions leak until
+  // the TTL sweep.
+  app.removeContentTypeParser("application/json");
+  app.addContentTypeParser(
+    "application/json",
+    { parseAs: "string" },
+    (_req, body, done) => {
+      const raw = typeof body === "string" ? body : body?.toString?.("utf8") ?? "";
+      if (raw.length === 0) return done(null, undefined);
+      try {
+        done(null, JSON.parse(raw));
+      } catch (err) {
+        done(err as Error, undefined);
+      }
+    }
+  );
+
   const cleanupExpiredSessions = async (): Promise<void> => {
     const now = Date.now();
     const ttl = getSessionTtlMs();


### PR DESCRIPTION
## Summary
- Every MCP `DELETE /` from ask-gateway was 400'ing with `FST_ERR_CTP_EMPTY_JSON_BODY` because the client sends `content-type: application/json` with no body and Fastify's default parser rejects that. The engine's DELETE handler never ran, so sessions leaked until the 30-min TTL sweep.
- Production evidence over the last 7 days: **1092** `Created new MCP session` vs **2** `Closed MCP session`. This is the root cause of the periodic OOM-kills on junction-engine (Apr 8, Apr 11, Apr 13) that locked us out of SSH.
- Fix applied on both sides (defense in depth).

**Engine (`apps/engine/src/routes/mcp.ts`)** — register a permissive JSON content-type parser scoped to the `mcpRoutes` plugin that treats empty bodies as `undefined`. Does not affect any other route.

**Ask-gateway (`apps/ask-gateway/app/mcp_client.py`)** — drop `content-type` on DELETE (no body), log non-2xx responses so future regressions are visible, and guarantee `close()` never raises.

## Test plan
- [ ] `bunx tsc --noEmit` clean (verified locally)
- [ ] Verified parser behavior with a minimal Fastify repro: `DELETE` with empty body + `application/json` now reaches the route handler (200); valid/invalid JSON POSTs still parse/reject as before.
- [ ] After merge + deploy, confirm `Closed MCP session` count roughly matches `Created new MCP session` in junction-engine journal.
- [ ] Watch bun RSS growth on the host over 48h — should stay flat instead of climbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)