### PR TITLE
Add hourly GitHub Actions cron for seat updates

### DIFF
--- a/.github/workflows/seats-cron.yml
+++ b/.github/workflows/seats-cron.yml
@@ -1,0 +1,43 @@
+name: Seats Cron
+
+on:
+  schedule:
+    # Hourly at :00 (GitHub Actions scheduling is best-effort; real delay can be 5-15 min under load).
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      term:
+        description: "Term code (e.g. 1272 for Fall 2026)"
+        required: true
+        default: "1272"
+
+concurrency:
+  group: seats-cron
+  cancel-in-progress: false
+
+jobs:
+  update-seats:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      SERVICE_ROLE_KEY: ${{ secrets.SERVICE_KEY }}
+      API_ACCESS_TOKEN: ${{ secrets.API_ACCESS_TOKEN }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: apps/database
+        run: bun install --frozen-lockfile
+
+      - name: Update seats + sync Redis
+        working-directory: apps/database
+        run: bun run update:seats:once ${{ github.event.inputs.term || '1272' }}

--- a/.github/workflows/seats-cron.yml
+++ b/.github/workflows/seats-cron.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
       PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
       SERVICE_ROLE_KEY: ${{ secrets.SERVICE_KEY }}
       API_ACCESS_TOKEN: ${{ secrets.API_ACCESS_TOKEN }}

--- a/apps/database/package.json
+++ b/apps/database/package.json
@@ -10,6 +10,7 @@
         "ratings-supabase": "bun src/scripts/supabase/ratings.ts",
         "update:courses": "bun src/scripts/update/courses.ts",
         "update:seats": "bun src/scripts/update/seats.ts",
+        "update:seats:once": "bun src/scripts/update/seats-once.ts",
         "db:start": "docker compose up",
         "db:schema": "bun src/db/generate-dbml.ts",
         "db:generate": "drizzle-kit generate",

--- a/apps/database/src/scripts/update/seats-once.ts
+++ b/apps/database/src/scripts/update/seats-once.ts
@@ -1,0 +1,19 @@
+import { updateSeats } from "./seats";
+import { redisTransfer } from "../supabase/redis";
+import { TERMS } from "../supabase/shared";
+
+const termArg = process.argv[2];
+if (!termArg) {
+    throw new Error("Usage: bun src/scripts/update/seats-once.ts <term>");
+}
+
+const term = parseInt(termArg, 10);
+if (Number.isNaN(term) || !TERMS.includes(term)) {
+    throw new Error(`Invalid term: ${termArg}`);
+}
+
+console.log(`One-shot seat update for term ${term}`);
+await updateSeats(term);
+await redisTransfer(term);
+console.log("Redis sync complete");
+process.exit(0);

--- a/apps/database/src/scripts/update/seats-once.ts
+++ b/apps/database/src/scripts/update/seats-once.ts
@@ -1,6 +1,6 @@
-import { updateSeats } from "./seats";
+import { supabase, TERMS } from "../supabase/shared";
+import { fetchRegSeats } from "../shared/reg-fetchers";
 import { redisTransfer } from "../supabase/redis";
-import { TERMS } from "../supabase/shared";
 
 const termArg = process.argv[2];
 if (!termArg) {
@@ -12,8 +12,63 @@ if (Number.isNaN(term) || !TERMS.includes(term)) {
     throw new Error(`Invalid term: ${termArg}`);
 }
 
+const BATCH_SIZE = 30;
+const startTime = Date.now();
+
 console.log(`One-shot seat update for term ${term}`);
-await updateSeats(term);
+
+const { data: courses, error: courseErr } = await supabase
+    .from("courses")
+    .select("id, listing_id")
+    .eq("term", term);
+
+if (courseErr) throw new Error(courseErr.message);
+if (!courses || courses.length === 0) {
+    throw new Error(`No courses found for term ${term}`);
+}
+
+console.log(`Fetched ${courses.length} courses`);
+
+let updateCount = 0;
+let errorCount = 0;
+
+for (let i = 0; i < courses.length; i += BATCH_SIZE) {
+    const batch = courses.slice(i, i + BATCH_SIZE);
+    const listingIds = batch.map(c => c.listing_id);
+
+    const seatData = await fetchRegSeats(listingIds, term);
+
+    for (const seat of seatData) {
+        const course = batch.find(c => c.listing_id === seat.listingId);
+        if (!course) continue;
+
+        for (const section of seat.sections) {
+            const { error: updateErr } = await supabase
+                .from("sections")
+                .update({
+                    cap: section.cap,
+                    tot: section.tot,
+                    status: section.status
+                })
+                .eq("num", section.num)
+                .eq("course_id", course.id);
+
+            if (updateErr) {
+                errorCount++;
+                console.error(
+                    `Section ${section.num} / course ${course.listing_id}: ${updateErr.message}`
+                );
+                continue;
+            }
+            updateCount++;
+        }
+    }
+}
+
+console.log(
+    `Section updates: ${updateCount} ok, ${errorCount} failed in ${(Date.now() - startTime) / 1000}s`
+);
+
 await redisTransfer(term);
-console.log("Redis sync complete");
+
 process.exit(0);

--- a/apps/database/src/scripts/update/seats.ts
+++ b/apps/database/src/scripts/update/seats.ts
@@ -73,6 +73,6 @@ export const updateSeatsForever = async (term: number) => {
 
 const isMainModule = process.argv[1] === import.meta.url.slice(7);
 if (isMainModule) {
-    console.log("Updating seats for term 1254");
-    updateSeatsForever(1254);
+    console.log("Updating seats for term 1272");
+    updateSeatsForever(1272);
 }


### PR DESCRIPTION
## Summary
- Restores the seat-update loop previously running on a local mac mini. Runs once per hour via GitHub Actions (`.github/workflows/seats-cron.yml`) — keeps `sections.cap/tot/status` current in Postgres (Supabase) and the `courses-<term>` / `sections-<term>` Redis keys the web app reads from.
- Adds `apps/database/src/scripts/update/seats-once.ts` — a one-shot entry that fetches listings via Supabase, pulls fresh seat data from the Princeton registrar API (`fetchRegSeats`), writes updates through the Supabase client (no Drizzle / no direct Postgres connection), then calls `redisTransfer(term)` to refresh Redis, then exits.
- Bumps the CLI default in `seats.ts` from `1254` (Spring 2025) to `1272` (Fall 2026). Legacy `updateSeatsForever` only — doesn't affect the cron.

## No new secrets required
The workflow reads only env vars that are already present as repo secrets: `PUBLIC_SUPABASE_URL`, `SERVICE_KEY` (mapped to env `SERVICE_ROLE_KEY`), `API_ACCESS_TOKEN`, `REDIS_PASSWORD`.

(Earlier version of this PR used Drizzle + a direct Postgres URL, requiring a new `DATABASE_URL` secret. Dropped in favor of the Supabase-client approach that matches `apps/web/src/lib/scripts/scraper/newRapid.ts`.)

## Notes / tradeoffs
- GitHub Actions scheduled workflows are best-effort; expected delay can be 5–15 min on top of the declared schedule. Hourly cadence is fine for seat counts, but much coarser than the ~5s loop Joshua had on the mac mini. If tighter freshness is needed later, an SST `Cron` alongside `calRefresh`, or a systemd timer on the `junction-engine` EC2, would be better fits.
- Updates go row-by-row through Supabase REST (one `update` per section). Slower than a Drizzle `UPDATE` would be, but total runtime is still well under the 15-min job timeout. No retry on transient failures — bad updates are logged and counted but don't abort the run.
- `concurrency: seats-cron` with `cancel-in-progress: false` prevents overlap if a run spills past the hour.

## Test plan
- [x] Merge to `main`
- [x] Manually trigger via Actions → "Seats Cron" → "Run workflow" (default term `1272`)
- [x] Confirm workflow is green; logs show `Section updates: N ok, 0 failed` and `Finished transferring data to Redis in X ms`
- [x] Spot-check a handful of `sections.tot` / `sections.cap` values in Supabase against the registrar
- [ ] Verify Redis keys `courses-1272` and `sections-1272` reflect the update
- [x] Wait one natural hourly trigger and confirm it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)