### PR TITLE
Fix seats cron: map status to smallint

### DIFF
--- a/apps/database/src/scripts/update/seats-once.ts
+++ b/apps/database/src/scripts/update/seats-once.ts
@@ -12,6 +12,10 @@ if (Number.isNaN(term) || !TERMS.includes(term)) {
     throw new Error(`Invalid term: ${termArg}`);
 }
 
+// sections.status is a smallint in Supabase (0 = open, 1 = closed/canceled),
+// even though Drizzle's schema.ts types it as a text enum. Map before writing.
+const toStatusInt = (s: string): number => (s === "open" ? 0 : 1);
+
 const BATCH_SIZE = 30;
 const startTime = Date.now();
 
@@ -48,7 +52,7 @@ for (let i = 0; i < courses.length; i += BATCH_SIZE) {
                 .update({
                     cap: section.cap,
                     tot: section.tot,
-                    status: section.status
+                    status: toStatusInt(section.status)
                 })
                 .eq("num", section.num)
                 .eq("course_id", course.id);
@@ -70,5 +74,14 @@ console.log(
 );
 
 await redisTransfer(term);
+
+const total = updateCount + errorCount;
+const failureRate = total > 0 ? errorCount / total : 0;
+if (failureRate > 0.1) {
+    console.error(
+        `Failure rate ${(failureRate * 100).toFixed(1)}% (${errorCount}/${total}) — exiting non-zero`
+    );
+    process.exit(1);
+}
 
 process.exit(0);


### PR DESCRIPTION
## Summary
Follow-up to #167. First production run (24591663327) surfaced two bugs:

1. **Type mismatch**: `sections.status` is actually a `smallint` column in Supabase (`0` = open, `1` = closed/canceled), not the text enum `apps/database/src/db/schema.ts` declares. 2451 of 2522 updates failed with `invalid input syntax for type smallint: "open"`; `redisTransfer` then overwrote Redis with mostly stale rows. Fix matches the numeric status convention in `apps/web/src/lib/scripts/scraper/newRapid.ts`.

2. **Silent failure**: `process.exit(0)` ran unconditionally, so the workflow was green despite near-total failure. Now exits non-zero when error rate > 10%, making systemic breakage visible in the Actions UI while tolerating occasional transient errors.

## Out of scope
The Drizzle schema in `apps/database/src/db/schema.ts` is stale (claims `statusEnum`) and should be corrected in a separate PR alongside any other drift.

## Test plan
- [ ] Merge
- [ ] Trigger Actions → "Seats Cron" → "Run workflow" (term `1272`)
- [ ] Expect green run, logs showing `Section updates: N ok, <~10% failed` and `Finished transferring data to Redis`
- [ ] Spot-check `sections.status` values in Supabase are numeric (0/1) and reflect the current registrar state

🤖 Generated with [Claude Code](https://claude.com/claude-code)