### PR TITLE
Raise Ask gateway tier budgets, restore Sonnet 4.6 for tier 1

### DIFF
--- a/apps/ask-gateway/app/usage_tracker.py
+++ b/apps/ask-gateway/app/usage_tracker.py
@@ -1,7 +1,7 @@
 """Per-user usage tracking with tiered quota system, persisted to Supabase.
 
-Tier 1: Claude Sonnet 4.6 — $0.50 budget
-Tier 2: Claude Haiku 4.5 — $0.25 budget (auto-downgrade when Tier 1 exhausted)
+Tier 1: Claude Sonnet 4.6 — $3.00 budget
+Tier 2: Claude Haiku 4.5 — $1.00 budget (auto-downgrade when Tier 1 exhausted)
 Exhausted: No more requests until next 8-hour window
 
 Resets at 12:00 AM, 8:00 AM, 4:00 PM US Eastern.
@@ -20,9 +20,9 @@ logger = logging.getLogger("ask-gateway.usage")
 
 TIER1_MODEL = "anthropic/claude-sonnet-4.6"
 TIER2_MODEL = "anthropic/claude-haiku-4.5"
-TIER1_BUDGET = 0.50
-TIER2_BUDGET = 0.25
-TOTAL_BUDGET = TIER1_BUDGET + TIER2_BUDGET  # $0.75
+TIER1_BUDGET = 3.00
+TIER2_BUDGET = 1.00
+TOTAL_BUDGET = TIER1_BUDGET + TIER2_BUDGET  # $4.00
 WINDOW_HOURS = 8
 
 _ET_OFFSET = timezone(timedelta(hours=-5))


### PR DESCRIPTION
## Summary
- Tier 1 model reverted from `claude-haiku-4.5` back to `claude-sonnet-4.6`
- Tier 1 budget: $0.50 -> $3.00
- Tier 2 budget: $0.25 -> $1.00
- Total per 8h window: $0.75 -> $4.00

Window/reset logic and tier-downgrade behavior unchanged.

## Test plan
- [ ] Verify first request in a fresh window routes to Sonnet 4.6
- [ ] Verify auto-downgrade to Haiku after Tier 1 budget exhausted
- [ ] Verify block at $4.00 total with correct resetSeconds