### PR TITLE
(bug) prevent course refresh from deleting unrelated sections

### DIFF
--- a/apps/web/src/lib/scripts/scraper/getallcourses.ts
+++ b/apps/web/src/lib/scripts/scraper/getallcourses.ts
@@ -308,6 +308,9 @@ export const getAllCourses = async (
             const removedSections = exisSectionNums.filter(
                 x => !newSectionNums.includes(x)
             );
+            const removedSectionIds = exisSections
+                .filter(x => removedSections.includes(x.num))
+                .map(x => x.id);
 
             // Check for duplicate sections and prune them from supabase
             const duplicateSections: number[] = [];
@@ -345,11 +348,11 @@ export const getAllCourses = async (
             // }
 
             // Prune removed sections
-            if (removedSections.length > 0) {
+            if (removedSectionIds.length > 0) {
                 const { error } = await supabase
                     .from("sections")
                     .delete()
-                    .in("num", removedSections);
+                    .in("id", removedSectionIds);
 
                 if (error) {
                     console.log(


### PR DESCRIPTION
## Summary

- Restrict admin course-refresh pruning to section rows already fetched for the current course.
- Delete removed sections by `id` instead of by registrar class `num`.

## Root Cause

`getAllCourses` correctly queried existing sections with `.eq("course_id", courseId)`, but the delete used only `.in("num", removedSections)`. Registrar class numbers are not table-wide unique, so refreshing one course could delete unrelated `sections` rows from other courses that happened to share the same `num`.

## Validation

- `npx prettier --check src/lib/scripts/scraper/getallcourses.ts`
- `git diff --check`

`npm run check` and `npm run lint` were also attempted, but they still fail on existing repo-wide Svelte/Supabase typing and lint issues unrelated to this one-file patch.

*(PR Body Written By Codex)*
