### PR TITLE
(bug) preserve canceled seat status

### DIFF
--- a/apps/database/src/scripts/update/seats-once.ts
+++ b/apps/database/src/scripts/update/seats-once.ts
@@ -1,6 +1,7 @@
 import { supabase, TERMS } from "../supabase/shared";
 import { fetchRegSeats } from "../shared/reg-fetchers";
 import { redisTransfer } from "../supabase/redis";
+import type { Status } from "../shared/db-types";
 
 const termArg = process.argv[2];
 if (!termArg) {
@@ -12,9 +13,17 @@ if (Number.isNaN(term) || !TERMS.includes(term)) {
     throw new Error(`Invalid term: ${termArg}`);
 }
 
-// sections.status is a smallint in Supabase (0 = open, 1 = closed/canceled),
-// even though Drizzle's schema.ts types it as a text enum. Map before writing.
-const toStatusInt = (s: string): number => (s === "open" ? 0 : 1);
+type SupabaseStatus = 0 | 1 | 2;
+
+// sections.status is a smallint in Supabase, even though Drizzle's schema.ts
+// types it as a text enum. Map before writing.
+const STATUS_MAP: Record<Status, SupabaseStatus> = {
+    open: 0,
+    closed: 1,
+    canceled: 2
+};
+
+const toStatusInt = (s: Status): SupabaseStatus => STATUS_MAP[s];
 
 const BATCH_SIZE = 30;
 const startTime = Date.now();


### PR DESCRIPTION
## Summary

- Preserve canceled section status when the one-shot seats cron writes seat updates back to Supabase.
- Replace the `open ? 0 : 1` conversion with the same explicit smallint mapping used by the full course loaders: `open = 0`, `closed = 1`, `canceled = 2`.
- Type the mapper against the registrar status union so future status additions cannot silently collapse into the wrong value.

## Root Cause

The full import paths encode canceled sections as `2`, and ReCal+ relies on that value for filters such as "No Cancelled". The one-shot seats cron introduced for smallint writes mapped every non-open registrar status to `1`, so any canceled section touched by the cron was rewritten as closed and then exported to Redis with the wrong status.

## Validation

- `./node_modules/.bin/prettier --check src/scripts/update/seats-once.ts`
- `./node_modules/.bin/eslint src/scripts/update/seats-once.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`

I also restored the `bun.lockb` churn from the local dependency install; the PR only changes `seats-once.ts`.

*(PR Body Written By Codex)*
