### PR TITLE
fix(database): use API_ACCESS_TOKEN for listings (drop Cloudflare-blocked site scrape)

### DIFF
--- a/apps/database/src/scripts/shared/reg-fetchers.ts
+++ b/apps/database/src/scripts/shared/reg-fetchers.ts
@@ -25,14 +25,12 @@ const REG_PUBLIC_URL =
 // API endpoint for the registrar student-app API
 const REG_API_URL = "https://api.princeton.edu/student-app/1.0.3/";
 
-// Gets the API token for use in the course listings API
-const getToken = async () => {
-    const response = await fetch(
-        "https://registrar.princeton.edu/course-offerings"
-    );
-    const text = await response.text();
-    return "Bearer " + text.split('apiToken":"')[1].split('"')[0];
-};
+// The public course-offerings classes API is served from the api.princeton.edu
+// gateway and accepts the same API_ACCESS_TOKEN we use for the student-app API
+// (see fetchRegDeptCourses/fetchRegSeats). We previously scraped a short-lived
+// apiToken from the registrar.princeton.edu website, but that page sits behind a
+// Cloudflare bot challenge that 403s from datacenter IPs (e.g. the cron box), so
+// we authenticate with API_ACCESS_TOKEN instead — no website scrape required.
 
 //----------------------------------------------------------------------
 // Fetcher Functions
@@ -43,7 +41,8 @@ const getToken = async () => {
  * @param term Term code
  */
 export const fetchRegListings = async (term: number): Promise<RegListing[]> => {
-    const token = await getToken();
+    const token = process.env.API_ACCESS_TOKEN;
+    if (!token) throw new Error("API access token not found");
 
     const rawCourseList = await fetch(`${REG_PUBLIC_URL}${term}`, {
         method: "GET",


### PR DESCRIPTION
## Problem
`fetchRegListings` obtained its bearer token by scraping `apiToken` from **registrar.princeton.edu/course-offerings**. That page sits behind a **Cloudflare bot challenge** that returns `403 Just a moment...` from datacenter IPs. It works intermittently from laptops but **fails reliably from AWS** — which broke `update-supabase` (listings → courses → instructors) when run on the new course-update cron box (`junction-engine` EC2).

## Fix
The public course-offerings **classes API** is served from the `api.princeton.edu` gateway and accepts the same `API_ACCESS_TOKEN` already used by `fetchRegDeptCourses` / `fetchRegSeats`. Authenticate `fetchRegListings` with `API_ACCESS_TOKEN` and remove the website scrape (`getToken`) entirely. No more Cloudflare dependency.

## Verification
- `fetchRegListings(1262)` → 1371 listings, and COS217 F25 instructors load (incl. **Kevin Negy**) — from both a laptop and the EC2 box (HTTP 200 on `/registrar/course-offerings/classes/1262` with `API_ACCESS_TOKEN`).
- Full `update-supabase 1262` and `update-supabase 1272 --grading` ran green on the box; Supabase + Redis reflect the data.

Resolves the data-pull half of TIG-244 / TIG-245 and unblocks the course-update cron.